### PR TITLE
#15 - Fix jest watch infinite loop

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -13,6 +13,9 @@
   "moduleNameMapper": {
     "\\.(css|less|sass|scss)$": "<rootDir>/src/tests/__mocks__/stylesheetMock.js"
   },
+  "watchPathIgnorePatterns": [
+    "/tests_output/"
+  ],
   "reporters": [
     "default",
     [

--- a/src/components/Expense.js
+++ b/src/components/Expense.js
@@ -28,7 +28,7 @@ export class Expense extends React.Component {
     this.setState({ showConfirmModal: false });
   }
 
-  startRemove () {
+  startRemove = () => {
     this.props.startRemoveExpense({ id: this.props.id });
     this.setState({ showConfirmModal: false });
   }


### PR DESCRIPTION
watchPathIgnorePatterns property has been added to jest configuration, to ignore test-results files generated under /tests_output/ directory.

This fixes the infinite loop bug.
